### PR TITLE
Don't make the format updater a workflow dependency.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
 name: Lint and Format Checks
 
 on:
-  workflow_run:
-    workflows: ["format.yml"]
-    types: [completed]
+  push:
+    branches:
+      - '**'
 
 jobs:
   lint:

--- a/docs/~notes.txt
+++ b/docs/~notes.txt
@@ -88,12 +88,13 @@ DB_URL='<Internal Database URL>/app_db'
 
 
 Misc/TODO:
-* Cleanup this very doc (should be .md)
-* pettier, lint (and workflows)
-* The render Build (or Start) entry needs (???):
-   python manage.py collectstatic --noinput
-   DJANGO_SETTINGS_MODULE=config.settings / WhiteNoise
-* seeding topics (for dev at least!)
+* DB Seeding (topics / entries) for dev
+  - Local script to add an app admin
 * Insomnia routes and export
+  - Delete Entry route
+* Cleanup this very doc (should be .md)
 * Add README.md
-* Implement a dockerized dev environment that uses gunicorn --reload and postgres (container maybe)
+* Dockerize
+  - dev environment can use 'gunicorn --reload'
+  - maybe a postgres container too?
+  - deploy container to Render?


### PR DESCRIPTION
Dependency workflows are detached and so they can't be directly associated with a PR. I would rather have checks that I can add to branch protection rules